### PR TITLE
Fix undesired relay activation on boot

### DIFF
--- a/main.py
+++ b/main.py
@@ -21,7 +21,7 @@ STATE = {
 
 # setup outputs
 buzzer = PWM(Pin(config.BUZZER_PIN), freq=400, duty=0)
-lock_pin = Pin(config.LOCK_PIN, Pin.OUT)
+lock_pin = Pin(config.LOCK_PIN, Pin.OUT, value=config.LOCK_REVERSED)
 led = Pin(config.LED_PIN, Pin.OUT)
 
 


### PR DESCRIPTION
When `LOCK_REVERSED = True` in `config.py` the lock pin state isn't specified which can leave the relay activated posing a security risk. This fixes that issue by setting the state explicitly on boot.