### PR TITLE
Some boards need txpower set for wifi to work

### DIFF
--- a/main.py
+++ b/main.py
@@ -185,7 +185,7 @@ local_mac = ubinascii.hexlify(wlan.config(
     'mac')).decode()  # store our mac address
 
 wlan.active(True)
-wlan.config(dhcp_hostname="MM_Controller_" + local_mac)
+wlan.config(dhcp_hostname="MM_Controller_" + local_mac, txpower=8.5)
 
 wlan_connecting_start = time.ticks_ms()
 led_toggle_last_update = time.ticks_ms()


### PR DESCRIPTION
The Wemos C3 mini and possibly other boards require txpower to be set for wifi to work.